### PR TITLE
Fix for the "cannot read properties of undefined" error

### DIFF
--- a/squid-gen-evm/src/util.ts
+++ b/squid-gen-evm/src/util.ts
@@ -40,7 +40,7 @@ export function getArchive(str: string): SquidArchive {
             value: str,
             kind: 'url',
         }
-    } else if (archivesRegistryEVM.archives.some((a) => a.network === str)) {
+    } else if (archivesRegistryEVM().archives.some((a) => a.network === str)) {
         return {
             value: str,
             kind: 'name',

--- a/squid-gen-ink/src/util.ts
+++ b/squid-gen-ink/src/util.ts
@@ -19,7 +19,7 @@ export function getArchive(str: string): SquidArchive {
             value: str,
             kind: 'url',
         }
-    } else if (archivesRegistrySubstrate.archives.some((a) => a.network === str)) {
+    } else if (archivesRegistrySubstrate().archives.some((a) => a.network === str)) {
         return {
             value: str,
             kind: 'name',


### PR DESCRIPTION
The code attempted to extract `.archive` directly from `archivesRegistry...` function objects, now it calls them.

	modified:   squid-gen-evm/src/util.ts
	modified:   squid-gen-ink/src/util.ts